### PR TITLE
AE2 recipes using Natura crafting table only

### DIFF
--- a/scripts/AppliedEnergistics.zs
+++ b/scripts/AppliedEnergistics.zs
@@ -12,7 +12,7 @@ val furnace = <minecraft:furnace>;
 val glowstone = <ore:dustGlowstone>;
 val diamond = <ore:gemDiamond>;
 val piston = <minecraft:piston>;
-val crafter = <ore:crafterWood>;
+val crafter = <ore:craftingTableWood>;
 val hopper = <ore:blockHopper>;
 
 val quartz = <appliedenergistics2:tile.BlockQuartzGlass>;


### PR DESCRIPTION
Currently, AE2 recipes including a crafting table are using only Natura crafting tables. This change will oredict in vanilla crafting tables as well.
