### PR TITLE
silver dust not smelting in vanilla furnace patch

### DIFF
--- a/scripts/OreDict.zs
+++ b/scripts/OreDict.zs
@@ -12,6 +12,24 @@ ironplate.add(<Railcraft:part.plate>);
 val steelplate = <ore:plateSteel>;
 steelplate.add(<Railcraft:part.plate:1>);
 
+#patch.omega for silver
+#hotfix for silver ingots
+val ingot_silver = <ore:ingotSilver>;
+ingot_silver.add(<ImmersiveEngineering:metal:3>);
+ingot_silver.add(<ElectriCraft:electricraft_item_ingots:2>);
+#ingot_silver.add(<ReactorCraft:reactorcraft:item_ingots:3>);
+ingot_silver.add(<RotaryCraft:rotarycraft_item_compacts:7>);
+
+
+#patch.omega for silver
+#hotfix for silver dusts
+val dust_silver = <ore:dustSilver>;
+dust_silver.add(<ImmersiveEngineering:metal:13>);
+dust_silver.add(<globbypotato_rockhounding:globbypotato_rockhounding_metalDusts:23>);
+
+
+
+
 #Add all harder ores to their own ore dictionary 'cause stupid
 <ore:oreRedstoneHard0>.add(<HarderOres:ore_redstone:0>);
 <ore:oreRedstoneHard1>.add(<HarderOres:ore_redstone:1>);

--- a/scripts/Vanilla.zs
+++ b/scripts/Vanilla.zs
@@ -11,6 +11,10 @@ val ingot = <RotaryCraft:rotarycraft_item_shaftcraft:1>;
 val rod = <RotaryCraft:rotarycraft_item_shaftcraft:2>;
 val plIron = <ore:plateIron>;
 
+#patch.omega for silver
+val ingot_silver = <ore:ingotSilver>;
+val dust_silver = <ore:dustSilver>;
+
 #remove all vanilla armor creation
 recipes.remove(<minecraft:iron_boots>);
 <minecraft:iron_boots>.addTooltip(format.white("DISABLED: Use HSLA Steel armor instead."));
@@ -50,3 +54,7 @@ recipes.remove(hopper);
 recipes.addShaped(hopper * 1, [[plIron,null,plIron],[plIron,chest,plIron],[null,plIron,null]]);
 
 recipes.remove(<RotaryCraft:rotarycraft_item_shaftcraft:10> * 3);
+
+#patch.omega for silver
+#Adds a RockHounding silver dust to silver ingot recipes
+furnace.addRecipe(<ImmersiveEngineering:metal:3>, dust_silver);


### PR DESCRIPTION
This fixes rockhounding dusts not smelting in the vanilla furnace. It adds all relevant silver dusts to the ore:dustSilver ore dictionary entry, adds all silver ingots to the ore:ingotSilver ore dictionary entry, and adds a vanilla furnace entry wherein ore:dustSilver smelts into ImmersiveEngineering silver Ingot
