### PR TITLE
Fix Gold Ring/Gold Chain Link recipe conflict

### DIFF
--- a/scripts/GardenStuff.zs
+++ b/scripts/GardenStuff.zs
@@ -17,6 +17,9 @@ val acaciaLattice = <GardenStuff:lattice_wood:4>;
 val darkoakLattice = <GardenStuff:lattice_wood:5>;
 val ironLattice = <GardenStuff:lattice:0>;
 
+val goldLink = <GardenStuff:chain_link:1>;
+val goldNugget = <ore:nuggetGold>;
+
 recipes.remove(ironLattice * 16);
 recipes.addShaped(ironLattice * 16, [[null,iron,null],[iron,null,iron],[null,iron,null]]);
 
@@ -37,3 +40,6 @@ recipes.addShaped(acaciaLattice * 8, [[null,acaciaSlab,null],[acaciaSlab,acaciaS
 
 recipes.remove(darkoakLattice * 8);
 recipes.addShaped(darkoakLattice * 8, [[null,darkoakSlab,null],[darkoakSlab,darkoakSlab,darkoakSlab],[null,darkoakSlab,null]]);
+
+recipes.remove(goldLink * 3);
+recipes.addShaped(goldLink * 3, [[null, goldNugget, goldNugget],[goldNugget, null, goldNugget],[goldNugget,goldNugget,null]]);

--- a/scripts/Travellers.zs
+++ b/scripts/Travellers.zs
@@ -1,0 +1,7 @@
+#Travellers Gear
+
+val goldRing = <TravellersGear:simpleGear:2>;
+val goldNugget = <ore:nuggetGold>;
+
+recipes.remove(goldRing);
+recipes.addShaped(goldRing, [[goldNugget,goldNugget,null],[goldNugget, null, goldNugget],[null, goldNugget, goldNugget]]);  


### PR DESCRIPTION
-Rotate Gold Chain link recipe 90 degrees.
-Remove and re-add Gold Ring recipe. (Necessary; original recognizes both rotations)

Fixes: #443 
