### PR TITLE
Disable Adjacency Cores needing energy

### DIFF
--- a/config/Reika/ChromatiCraft.cfg
+++ b/config/Reika/ChromatiCraft.cfg
@@ -22,7 +22,7 @@
 
 
 "control setup" {
-    B:"Adjacency Upgrades Require Energy"=true
+    B:"Adjacency Upgrades Require Energy"=false
     B:"Allow Danger in Rainbow Forests"=true
     B:"Allow duplication wand to copy TileEntities"=false
     B:"Always Respawn EnderDragon"=false


### PR DESCRIPTION
-Disable Adjacency Core energy use until Chroma.wireless has a recipe.

Fixes: #452 
