### PR TITLE
Bug: Quest "A Simple Firearm" not completable

### DIFF
--- a/config/betterquesting/DefaultQuests.json
+++ b/config/betterquesting/DefaultQuests.json
@@ -5658,7 +5658,7 @@
               "OreDict": "",
               "Damage": 0,
               "tag": {
-                "ammo:4": 1,
+                "ammo:4": 0,
                 "camo:4": 0
               }
             },


### PR DESCRIPTION
You can't craft a Handgun with munition in it, so the quest isn't completable.

Fixed it.