### PR TITLE
Fixes TCon Knapsack Recipe

### DIFF
--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -10,6 +10,8 @@ mods.tconstruct.Smeltery.removeMelting(<minecraft:rail>);
 #Knapsack needs HSLA Tough Rod since Iron Tough Rod is disabled.
 val leather = <minecraft:leather>;
 val gold = <ore:ingotGold>;
+val alumbrass = <TConstruct:materials:14>;
 val rod = <TConstruct:toughRod:81>;
 recipes.remove(<TConstruct:knapsack>);
 recipes.addShaped(<TConstruct:knapsack>, [[leather,leather,leather],[rod,gold,rod],[leather,leather,leather]]);
+recipes.addShaped(<TConstruct:knapsack>, [[leather,leather,leather],[rod,alumbrass,rod],[leather,leather,leather]]);

--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -6,3 +6,10 @@ val gapple = <minecraft:golden_apple:1>;
 mods.tconstruct.Smeltery.removeMelting(apple);
 mods.tconstruct.Smeltery.removeMelting(gapple);
 mods.tconstruct.Smeltery.removeMelting(<minecraft:rail>);
+
+#Knapsack needs HSLA Tough Rod since Iron Tough Rod is disabled.
+val leather = <minecraft:leather>;
+val gold = <ore:ingotGold>;
+val rod = <TConstruct:toughRod:81>;
+recipes.remove(<TConstruct:knapsack>);
+recipes.addShaped(<TConstruct:knapsack>, [[leather,leather,leather],[rod,gold,rod],[leather,leather,leather]]);


### PR DESCRIPTION
Knapsack recipe required Iron Tough Rod which is disabled. Now requires HSLA Tough Rod instead.
Fixes #634